### PR TITLE
Make GitHub detect .0, .1, .2, and .3 as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.[0123] linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.0`, `.1`, `.2`, and `.3` files as Forth.

Thanks!
